### PR TITLE
Adding systemd unit files to ANGRYsearch

### DIFF
--- a/angrysearch-update-database.service
+++ b/angrysearch-update-database.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Update ANGRYsearch database.
+Documentation=https://github.com/DoTheEvo/ANGRYsearch/wiki
+DefaultDependencies=no
+Conflicts=shutdown.target
+Before=basic.target shutdown.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/share/angrysearch/angrysearch_update_database.py
+IOSchedulingClass=idle
+Slice=background.slice

--- a/angrysearch-update-database.timer
+++ b/angrysearch-update-database.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Update ANGRYsearch database every 6 hours.
+
+[Timer]
+OnStartupSec=5min
+OnUnitActiveSec=6h
+
+[Install]
+WantedBy=timers.target

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,13 @@ install -Dm644 angrysearch.svg "/usr/share/angrysearch/angrysearch.svg"
 install -Dm644 scandir.py "/usr/share/angrysearch/scandir.py"
 install -Dm644 resource_file.py "/usr/share/angrysearch/resource_file.py"
 install -Dm644 qdarkstylesheet.qss "/usr/share/angrysearch/qdarkstylesheet.qss"
+if [ -d /usr/lib/systemd/ ]; then
+  install -Dm angrysearch-update-database.service "${XDG_CONFIG_HOME:-${HOME}/.config}/systemd/user/angrysearch-update-database.service"
+  install -Dm angrysearch-update-database.timer "${XDG_CONFIG_HOME:-${HOME}/.config}/systemd/user/angrysearch-update-database.timer"
+  systemctl --user enable angrysearch-update-database.timer
+else
+  echo "Systemd not found on system - not installing service and timer units."
+fi
 
 ln -sf "/usr/share/angrysearch/angrysearch.py" "/usr/bin/angrysearch"
 ln -sf "/usr/share/angrysearch/angrysearch.svg" "/usr/share/pixmaps"


### PR DESCRIPTION
This PR adds ANGRYsearch-update-database.py as a systemd service and timer, activated 5 mins after startup, followed by every 6 hours of last activation.

Do let me know if there are any problems to patch out, but the systemd files should work flawlessly, they do on my system :)